### PR TITLE
Modal add user

### DIFF
--- a/src/api/endPointRoles.test.ts
+++ b/src/api/endPointRoles.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getRole, createRole } from "./endPointRoles";
+import { API_URL, END_POINTS } from "../config";
+import moock from "../moock/roles.json";
+import type {
+  IntRole,
+  RoleCreationRequest,
+  RoleCreationResponse,
+} from "./endPointRoles";
+
+// Set up mock data
+const mockRole = moock.role as IntRole;
+const mockGithubId = 123456;
+
+describe("endPointRoles", () => {
+  // Set up console spies
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getRole", () => {
+    it("should return role data when API responds successfully", async () => {
+      const mockRoleResponse = {
+        role: {
+          github_id: mockGithubId,
+          role: "admin",
+        },
+      };
+
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRoleResponse),
+        } as Response),
+      );
+
+      const result = await getRole(mockGithubId);
+
+      expect(result).toEqual(mockRoleResponse.role);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        `${API_URL}${END_POINTS.roles.lists}${mockGithubId}`,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it("should return mock role when API returns error", async () => {
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        } as Response),
+      );
+
+      const result = await getRole(mockGithubId);
+
+      expect(result).toEqual(mockRole);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("should return mock role when API returns error response", async () => {
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ error: "User not found" }),
+        } as Response),
+      );
+
+      const result = await getRole(mockGithubId);
+
+      expect(result).toEqual(mockRole);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("should handle AbortController errors", async () => {
+      const abortError = new DOMException(
+        "The operation was aborted",
+        "AbortError",
+      );
+      global.fetch = vi.fn(() => Promise.reject(abortError));
+
+      const result = await getRole(mockGithubId);
+
+      expect(result).toEqual(mockRole);
+      expect(console.warn).toHaveBeenCalledWith("Petición cancelada.");
+    });
+
+    it("should throw error for non-abort errors", async () => {
+      global.fetch = vi.fn(() => Promise.reject(new Error("Network error")));
+
+      await expect(getRole(mockGithubId)).rejects.toThrow(
+        "Error al obtener los roles",
+      );
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("createRole", () => {
+    const mockRequestBody: RoleCreationRequest = {
+      authorized_github_id: 555555,
+      github_id: mockGithubId,
+      role: "student",
+    };
+
+    const mockSuccessResponse: RoleCreationResponse = {
+      message: "Role created successfully",
+      role: {
+        github_id: mockGithubId,
+        role: "student",
+      },
+    };
+
+    it("should successfully create a role", async () => {
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockSuccessResponse),
+        } as Response),
+      );
+
+      const result = await createRole(mockRequestBody);
+
+      expect(result).toEqual(mockSuccessResponse);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(`${API_URL}${END_POINTS.roles.post}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(mockRequestBody),
+      });
+    });
+
+    it("should throw error when API returns error", async () => {
+      const errorMessage = "Unauthorized access";
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          json: () => Promise.resolve({ message: errorMessage }),
+        } as Response),
+      );
+
+      await expect(createRole(mockRequestBody)).rejects.toThrow(errorMessage);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("should handle network errors", async () => {
+      global.fetch = vi.fn(() => Promise.reject(new Error("Network error")));
+
+      await expect(createRole(mockRequestBody)).rejects.toThrow();
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("should use status text when error response has no message", async () => {
+      global.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: () => Promise.resolve({}),
+        } as Response),
+      );
+
+      await expect(createRole(mockRequestBody)).rejects.toThrow(
+        "Error 500: Internal Server Error",
+      );
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/endPointRoles.ts
+++ b/src/api/endPointRoles.ts
@@ -1,37 +1,6 @@
 import { API_URL, END_POINTS } from "../config";
 import moock from "../moock/roles.json";
 
-// En el cuerpo de la solitud tendra:
-// authorized_github_id: 9999999,
-// github_id: 23434,
-// role: "student"
-
-// GET{base_url}/api/roles
-// {
-// 	"message": "Role found.",
-// 	"role": {
-// 	  "github_id": 6729608,
-// 	  "role": "admin",
-// 	  "isAdmin": true,
-// 	  "isStudent": false,
-// 	  "isMentor": false,
-// 	  "isAnonymous": false
-// 	}
-//   }
-
-// POST{base_url}/api/roles
-// "message": "Role created successfully",
-//   "role": {
-//     "github_id": 23434,
-//     "role": "student",
-//   }
-
-// USER
-// displayName : "Jordi Terradas"
-// id : 119063441
-// photoURL : "https://avatars.githubusercontent.com/u/119063441?v=4"
-// role : "admin"
-
 interface IntRole {
   github_id: number;
   role: string;
@@ -39,7 +8,6 @@ interface IntRole {
   isAdmin: boolean;
   isStudent: boolean;
   isMentor: boolean;
-  isAnonymous: boolean;
 }
 
 interface RoleCreationRequest {
@@ -66,7 +34,7 @@ const getRole = async (github_id: number): Promise<IntRole> => {
 	  const response = await fetch(url, { signal });
   
 	  if (!response.ok) {
-		console.warn(`Error ${response.status}: ${response.statusText}`);
+		console.warn(`Error ${response.status}: ${response.statusText}, usaremos el mock`);
 		return mockRoles;
 	  }
   
@@ -97,7 +65,7 @@ const getRole = async (github_id: number): Promise<IntRole> => {
   
   const createRole = async (body: RoleCreationRequest): Promise<RoleCreationResponse> => {
 	try {
-	  const response = await fetch(`${API_URL}${END_POINTS.roles.post}/${body.github_id}`, {
+	  const response = await fetch(`${API_URL}${END_POINTS.roles.post}`, {
 		method: "POST",
 		headers: {
 		  "Content-Type": "application/json",

--- a/src/api/endPointRoles.ts
+++ b/src/api/endPointRoles.ts
@@ -1,0 +1,121 @@
+import { API_URL, END_POINTS } from "../config";
+import moock from "../moock/roles.json";
+
+// En el cuerpo de la solitud tendra:
+// authorized_github_id: 9999999,
+// github_id: 23434,
+// role: "student"
+
+// GET{base_url}/api/roles
+// {
+// 	"message": "Role found.",
+// 	"role": {
+// 	  "github_id": 6729608,
+// 	  "role": "admin",
+// 	  "isAdmin": true,
+// 	  "isStudent": false,
+// 	  "isMentor": false,
+// 	  "isAnonymous": false
+// 	}
+//   }
+
+// POST{base_url}/api/roles
+// "message": "Role created successfully",
+//   "role": {
+//     "github_id": 23434,
+//     "role": "student",
+//   }
+
+// USER
+// displayName : "Jordi Terradas"
+// id : 119063441
+// photoURL : "https://avatars.githubusercontent.com/u/119063441?v=4"
+// role : "admin"
+
+interface IntRole {
+  github_id: number;
+  role: string;
+  isSuperAdmin: boolean;
+  isAdmin: boolean;
+  isStudent: boolean;
+  isMentor: boolean;
+  isAnonymous: boolean;
+}
+
+interface RoleCreationRequest {
+	authorized_github_id: number;
+	github_id: number;
+	role: string;
+  }
+  
+  interface RoleCreationResponse {
+	message: string;
+	role: {
+	  github_id: number;
+	  role: string;
+	};
+  }
+  
+  const mockRoles: IntRole = moock.role as IntRole;
+  
+const getRole = async (github_id: number): Promise<IntRole> => {
+	const controller = new AbortController();
+	const signal = controller.signal;
+	try {
+	  const url = `${API_URL}${END_POINTS.roles.lists}${github_id}`;
+	  const response = await fetch(url, { signal });
+  
+	  if (!response.ok) {
+		console.warn(`Error ${response.status}: ${response.statusText}`);
+		return mockRoles;
+	  }
+  
+	  const data = await response.json();
+	  
+	  // Succesful
+	  if (data && typeof data === 'object' && data.role) {
+		return data.role as IntRole;
+	  } 
+	  
+	  // Not found
+	  if (data && typeof data === 'object' && data.error) {
+		console.warn(`API Error: ${data.error}`);
+		return mockRoles;
+	  }
+	  
+	  // Other
+	  return mockRoles;
+	} catch (error) {
+	  if (error instanceof DOMException && error.name === "AbortError") {
+		console.warn("Petición cancelada.");
+		return mockRoles;
+	  }
+	  console.error("Error en getRole:", error);
+	  throw new Error("Error al obtener los roles");
+	}
+  };
+  
+  const createRole = async (body: RoleCreationRequest): Promise<RoleCreationResponse> => {
+	try {
+	  const response = await fetch(`${API_URL}${END_POINTS.roles.post}/${body.github_id}`, {
+		method: "POST",
+		headers: {
+		  "Content-Type": "application/json",
+		},
+		body: JSON.stringify(body),
+	  });
+  
+	  if (!response.ok) {
+		const errorData = await response.json();
+		throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
+	  }
+  
+	  return await response.json() as RoleCreationResponse;
+	} catch (error) {
+	  console.error("Error al crear rol:", error);
+	  throw error;
+	}
+  };
+  
+  export type { IntRole, RoleCreationRequest, RoleCreationResponse };
+  export { getRole, createRole };

--- a/src/api/endPointRoles.ts
+++ b/src/api/endPointRoles.ts
@@ -11,79 +11,85 @@ interface IntRole {
 }
 
 interface RoleCreationRequest {
-	authorized_github_id: number;
-	github_id: number;
-	role: string;
-  }
-  
-  interface RoleCreationResponse {
-	message: string;
-	role: {
-	  github_id: number;
-	  role: string;
-	};
-  }
-  
-  const mockRoles: IntRole = moock.role as IntRole;
-  
+  authorized_github_id: number;
+  github_id: number;
+  role: string;
+}
+
+interface RoleCreationResponse {
+  message: string;
+  role: {
+    github_id: number;
+    role: string;
+  };
+}
+
+const mockRoles: IntRole = moock.role as IntRole;
+
 const getRole = async (github_id: number): Promise<IntRole> => {
-	const controller = new AbortController();
-	const signal = controller.signal;
-	try {
-	  const url = `${API_URL}${END_POINTS.roles.lists}${github_id}`;
-	  const response = await fetch(url, { signal });
-  
-	  if (!response.ok) {
-		console.warn(`Error ${response.status}: ${response.statusText}, usaremos el mock`);
-		return mockRoles;
-	  }
-  
-	  const data = await response.json();
-	  
-	  // Succesful
-	  if (data && typeof data === 'object' && data.role) {
-		return data.role as IntRole;
-	  } 
-	  
-	  // Not found
-	  if (data && typeof data === 'object' && data.error) {
-		console.warn(`API Error: ${data.error}`);
-		return mockRoles;
-	  }
-	  
-	  // Other
-	  return mockRoles;
-	} catch (error) {
-	  if (error instanceof DOMException && error.name === "AbortError") {
-		console.warn("Petición cancelada.");
-		return mockRoles;
-	  }
-	  console.error("Error en getRole:", error);
-	  throw new Error("Error al obtener los roles");
-	}
-  };
-  
-  const createRole = async (body: RoleCreationRequest): Promise<RoleCreationResponse> => {
-	try {
-	  const response = await fetch(`${API_URL}${END_POINTS.roles.post}`, {
-		method: "POST",
-		headers: {
-		  "Content-Type": "application/json",
-		},
-		body: JSON.stringify(body),
-	  });
-  
-	  if (!response.ok) {
-		const errorData = await response.json();
-		throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
-	  }
-  
-	  return await response.json() as RoleCreationResponse;
-	} catch (error) {
-	  console.error("Error al crear rol:", error);
-	  throw error;
-	}
-  };
-  
-  export type { IntRole, RoleCreationRequest, RoleCreationResponse };
-  export { getRole, createRole };
+  const controller = new AbortController();
+  const signal = controller.signal;
+  try {
+    const url = `${API_URL}${END_POINTS.roles.lists}${github_id}`;
+    const response = await fetch(url, { signal });
+
+    if (!response.ok) {
+      console.warn(
+        `Error ${response.status}: ${response.statusText}, usaremos el mock`,
+      );
+      return mockRoles;
+    }
+
+    const data = await response.json();
+
+    // Succesful
+    if (data && typeof data === "object" && data.role) {
+      return data.role as IntRole;
+    }
+
+    // Not found
+    if (data && typeof data === "object" && data.error) {
+      console.warn(`API Error: ${data.error}`);
+      return mockRoles;
+    }
+
+    // Other
+    return mockRoles;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      console.warn("Petición cancelada.");
+      return mockRoles;
+    }
+    console.error("Error en getRole:", error);
+    throw new Error("Error al obtener los roles");
+  }
+};
+
+const createRole = async (
+  body: RoleCreationRequest,
+): Promise<RoleCreationResponse> => {
+  try {
+    const response = await fetch(`${API_URL}${END_POINTS.roles.post}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(
+        errorData.message || `Error ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    return (await response.json()) as RoleCreationResponse;
+  } catch (error) {
+    console.error("Error al crear rol:", error);
+    throw error;
+  }
+};
+
+export type { IntRole, RoleCreationRequest, RoleCreationResponse };
+export { getRole, createRole };

--- a/src/components/resources/AddUserModal.tsx
+++ b/src/components/resources/AddUserModal.tsx
@@ -15,19 +15,24 @@ const rolePermissions = {
   mentor: ["student"],
 };
 
-export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole, userID }) => {
+export const AddUsersModal: React.FC<AddUsersModalProps> = ({
+  onClose,
+  userRole,
+  userID,
+}) => {
   const [githubId, setGithubId] = useState("");
   const [selectedRole, setSelectedRole] = useState("");
 
   // Get available roles based on the user's role
-  const availableRoles = rolePermissions[userRole as keyof typeof rolePermissions] || [];
+  const availableRoles =
+    rolePermissions[userRole as keyof typeof rolePermissions] || [];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const requestBody = {
       authorized_github_id: Number(userID),
       github_id: Number(githubId),
-      role: selectedRole
+      role: selectedRole,
     };
     createRole(requestBody);
     console.log(requestBody);
@@ -36,18 +41,24 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole,
   };
 
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex justify-center items-center z-50">
-      <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-xl">
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex justify-center items-center z-50 overflow-visible">
+      <div className="bg-white rounded-xl p-8 w-full max-w-md shadow-xl">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-bold">Add Users</h2>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+          >
             ✕
           </button>
         </div>
 
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="username"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Github ID
             </label>
             <input
@@ -62,7 +73,10 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole,
           </div>
 
           <div className="mb-4">
-            <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="role"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Role
             </label>
             <select
@@ -82,7 +96,11 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole,
           </div>
 
           <div className="flex justify-end gap-2">
-            <ButtonComponent type="button" variant="secondary" onClick={onClose}>
+            <ButtonComponent
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+            >
               Cancel
             </ButtonComponent>
             <ButtonComponent type="submit" variant="primary">

--- a/src/components/resources/AddUserModal.tsx
+++ b/src/components/resources/AddUserModal.tsx
@@ -23,8 +23,8 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
   const [githubId, setGithubId] = useState("");
   const [selectedRole, setSelectedRole] = useState("");
 
-  const availableRoles = userRole 
-    ? (rolePermissions[userRole as keyof typeof rolePermissions] || [])
+  const availableRoles = userRole
+    ? rolePermissions[userRole as keyof typeof rolePermissions] || []
     : [];
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -35,14 +35,14 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
       role: selectedRole,
     };
     createRole(requestBody)
-    .then(() => {
-      // TODO add a toaster or something on success
-      onClose();
-    })
-    .catch(error => {
-      // TODO add something for errors too
-      console.error("Failed to create role:", error);
-    });
+      .then(() => {
+        // TODO add a toaster or something on success
+        onClose();
+      })
+      .catch((error) => {
+        // TODO add something for errors too
+        console.error("Failed to create role:", error);
+      });
     onClose();
   };
 

--- a/src/components/resources/AddUserModal.tsx
+++ b/src/components/resources/AddUserModal.tsx
@@ -5,7 +5,7 @@ import { createRole } from "../../api/endPointRoles";
 
 interface AddUsersModalProps {
   onClose: () => void;
-  userRole: string;
+  userRole: string | null;
   userID: number | string;
 }
 
@@ -23,9 +23,9 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
   const [githubId, setGithubId] = useState("");
   const [selectedRole, setSelectedRole] = useState("");
 
-  // Get available roles based on the user's role
-  const availableRoles =
-    rolePermissions[userRole as keyof typeof rolePermissions] || [];
+  const availableRoles = userRole 
+    ? (rolePermissions[userRole as keyof typeof rolePermissions] || [])
+    : [];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,9 +34,15 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
       github_id: Number(githubId),
       role: selectedRole,
     };
-    createRole(requestBody);
-    console.log(requestBody);
-
+    createRole(requestBody)
+    .then(() => {
+      // TODO add a toaster or something on success
+      onClose();
+    })
+    .catch(error => {
+      // TODO add something for errors too
+      console.error("Failed to create role:", error);
+    });
     onClose();
   };
 
@@ -65,7 +71,7 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
               type="text"
               id="username"
               className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              placeholder="Enter ID"
+              placeholder="Ingresa su ID"
               value={githubId}
               onChange={(e) => setGithubId(e.target.value)}
               required
@@ -77,7 +83,7 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
               htmlFor="role"
               className="block text-sm font-medium text-gray-700 mb-1"
             >
-              Role
+              Rol
             </label>
             <select
               id="role"
@@ -86,7 +92,7 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
               onChange={(e) => setSelectedRole(e.target.value)}
               required
             >
-              <option value="">Select a role</option>
+              <option value="">Selecciona su rol</option>
               {availableRoles.map((role) => (
                 <option key={role} value={role}>
                   {role}
@@ -101,10 +107,10 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({
               variant="secondary"
               onClick={onClose}
             >
-              Cancel
+              Cancelar
             </ButtonComponent>
             <ButtonComponent type="submit" variant="primary">
-              Add User
+              Añadir
             </ButtonComponent>
           </div>
         </form>

--- a/src/components/resources/AddUserModal.tsx
+++ b/src/components/resources/AddUserModal.tsx
@@ -31,6 +31,7 @@ export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole,
     };
     createRole(requestBody);
     console.log(requestBody);
+
     onClose();
   };
 

--- a/src/components/resources/AddUserModal.tsx
+++ b/src/components/resources/AddUserModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from "react";
+// import { useCtxUser } from "../../hooks/useCtxUser";
+import ButtonComponent from "../atoms/ButtonComponent";
+import { createRole } from "../../api/endPointRoles";
+
+interface AddUsersModalProps {
+  onClose: () => void;
+  userRole: string;
+  userID: number | string;
+}
+
+const rolePermissions = {
+  superadmin: ["admin", "mentor", "student"],
+  admin: ["mentor", "student"],
+  mentor: ["student"],
+};
+
+export const AddUsersModal: React.FC<AddUsersModalProps> = ({ onClose, userRole, userID }) => {
+  const [githubId, setGithubId] = useState("");
+  const [selectedRole, setSelectedRole] = useState("");
+
+  // Get available roles based on the user's role
+  const availableRoles = rolePermissions[userRole as keyof typeof rolePermissions] || [];
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const requestBody = {
+      authorized_github_id: Number(userID),
+      github_id: Number(githubId),
+      role: selectedRole
+    };
+    createRole(requestBody);
+    console.log(requestBody);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">Add Users</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+              Github ID
+            </label>
+            <input
+              type="text"
+              id="username"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              placeholder="Enter ID"
+              value={githubId}
+              onChange={(e) => setGithubId(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
+              Role
+            </label>
+            <select
+              id="role"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              value={selectedRole}
+              onChange={(e) => setSelectedRole(e.target.value)}
+              required
+            >
+              <option value="">Select a role</option>
+              {availableRoles.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <ButtonComponent type="button" variant="secondary" onClick={onClose}>
+              Cancel
+            </ButtonComponent>
+            <ButtonComponent type="submit" variant="primary">
+              Add User
+            </ButtonComponent>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ const END_POINTS = {
   roles: {
     lists: "users/user-signedin-as?github_id=" as EndPoints,
     post: "roles/" as EndPoints,
-  }
+  },
 };
 
 export { API_URL, END_POINTS };

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ const END_POINTS = {
     post: "resources/" as EndPoints,
   },
   roles: {
-    lists: "roles/" as EndPoints,
+    lists: "users/user-signedin-as?github_id=" as EndPoints,
     post: "roles/" as EndPoints,
   }
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,12 +1,16 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
-type EndPoints = "resources/" | "users/lists";
+type EndPoints = "resources/" | "users/lists" | "roles/";
 
 const END_POINTS = {
   resources: {
     lists: "resources/" as EndPoints,
     post: "resources/" as EndPoints,
   },
+  roles: {
+    lists: "roles/" as EndPoints,
+    post: "roles/" as EndPoints,
+  }
 };
 
 export { API_URL, END_POINTS };

--- a/src/moock/roles.json
+++ b/src/moock/roles.json
@@ -1,12 +1,7 @@
 {
   "message": "Role found.",
   "role": {
-    "github_id": 6729608,
-    "role": "superadmin",
-    "isSuperAdmin": true,
-    "isAdmin": false,
-    "isStudent": false,
-    "isMentor": false,
-    "isAnonymous": false
+    "github_id": 4,
+    "role": "admin"
   }
 }

--- a/src/moock/roles.json
+++ b/src/moock/roles.json
@@ -1,0 +1,12 @@
+{
+  "message": "Role found.",
+  "role": {
+    "github_id": 6729608,
+    "role": "superadmin",
+    "isSuperAdmin": true,
+    "isAdmin": false,
+    "isStudent": false,
+    "isMentor": false,
+    "isAnonymous": false
+  }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -31,7 +31,9 @@ export default function HomePage() {
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
-  const hasPermission = userRole ? ["superadmin", "admin", "mentor"].includes(userRole) : false;
+  const hasPermission = userRole
+    ? ["superadmin", "admin", "mentor"].includes(userRole)
+    : false;
 
   return (
     <main className="bg-white rounded-xl p-6 w-full text-center h-[inherit] max-h-[calc(100vh-114px)] overflow-auto">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,7 +11,7 @@ import { getRole } from "../api/endPointRoles";
 export default function HomePage() {
   const { signIn, signOut, user, error } = useCtxUser();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [userRole, setUserRole] = useState<string>("anonymous");
+  const [userRole, setUserRole] = useState<string>("visitor");
 
   // Handle log in
   useEffect(() => {
@@ -19,21 +19,20 @@ export default function HomePage() {
       getRole(user.id)
         .then((roleData) => {
           setUserRole(roleData.role);
-          console.log("Role fetched:", roleData);
         })
         .catch((err) => {
           console.error("Error fetching role:", err);
-          setUserRole("anonymous");
+          setUserRole("visitor");
         });
     } else {
-      setUserRole("anonymous");
+      setUserRole("visitor");
     }
   }, [user]);
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
-  // Permission to see AddUsers.tsx
+  // Permission to see AddUsers component
   const hasPermission = ["superadmin", "admin", "mentor"].includes(userRole);
 
   return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,29 +11,27 @@ import { getRole } from "../api/endPointRoles";
 export default function HomePage() {
   const { signIn, signOut, user, error } = useCtxUser();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [userRole, setUserRole] = useState<string>("visitor");
+  const [userRole, setUserRole] = useState<string | null>(null);
 
-  // Handle log in
   useEffect(() => {
     if (user && user.id) {
       getRole(user.id)
         .then((roleData) => {
-          setUserRole(roleData.role);
+          setUserRole(roleData?.role || null);
         })
         .catch((err) => {
           console.error("Error fetching role:", err);
-          setUserRole("visitor");
+          setUserRole(null);
         });
     } else {
-      setUserRole("visitor");
+      setUserRole(null);
     }
   }, [user]);
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
-  // Permission to see AddUsers component
-  const hasPermission = ["superadmin", "admin", "mentor"].includes(userRole);
+  const hasPermission = userRole ? ["superadmin", "admin", "mentor"].includes(userRole) : false;
 
   return (
     <main className="bg-white rounded-xl p-6 w-full text-center h-[inherit] max-h-[calc(100vh-114px)] overflow-auto">
@@ -47,8 +45,6 @@ export default function HomePage() {
             padding: "1rem",
           }}
         >
-          <h1>¡Bienvenid@ a la wiki de la IT Academy!</h1>
-
           {user ? (
             <article
               id={String(user.id)}
@@ -98,7 +94,7 @@ export default function HomePage() {
 
           {hasPermission && (
             <ButtonComponent onClick={openModal} className="mt-4">
-              Add users
+              Añadir Usuario
             </ButtonComponent>
           )}
         </article>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -61,7 +61,10 @@ export default function HomePage() {
                 height={64}
                 className="rounded-full border-2 border-white"
               />
-              <small className="font-bold" style={{ textTransform: "uppercase" }}>
+              <small
+                className="font-bold"
+                style={{ textTransform: "uppercase" }}
+              >
                 {user.displayName}
               </small>
               <button
@@ -86,7 +89,9 @@ export default function HomePage() {
                 <label htmlFor="terms">
                   <input name="terms" type="checkbox" /> Acepto términos legales
                 </label>
-                {error && <div className="error-message text-red-500 my-4">{error}</div>}
+                {error && (
+                  <div className="error-message text-red-500 my-4">{error}</div>
+                )}
               </div>
             </div>
           )}
@@ -123,7 +128,13 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-      {isModalOpen && hasPermission && <AddUsersModal onClose={closeModal} userRole={userRole} userID={user.id} />}
+      {isModalOpen && hasPermission && (
+        <AddUsersModal
+          onClose={closeModal}
+          userRole={userRole}
+          userID={user.id}
+        />
+      )}
     </main>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,9 +3,38 @@ import folder from "../assets/new-folder-dynamic-color.svg";
 import puzzle from "../assets/puzzle-dynamic-color.svg";
 import ok from "../assets/thumb-up-dynamic-color.svg";
 import { useCtxUser } from "../hooks/useCtxUser";
+import { useState, useEffect } from "react";
+import { AddUsersModal } from "../components/resources/AddUserModal";
+import ButtonComponent from "../components/atoms/ButtonComponent";
+import { getRole } from "../api/endPointRoles";
 
 export default function HomePage() {
   const { signIn, signOut, user, error } = useCtxUser();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [userRole, setUserRole] = useState<string>("anonymous");
+
+  // Handle log in
+  useEffect(() => {
+    if (user && user.id) {
+      getRole(user.id)
+        .then((roleData) => {
+          setUserRole(roleData.role);
+          console.log("Role fetched:", roleData);
+        })
+        .catch((err) => {
+          console.error("Error fetching role:", err);
+          setUserRole("anonymous");
+        });
+    } else {
+      setUserRole("anonymous");
+    }
+  }, [user]);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  // Permission to see AddUsers.tsx
+  const hasPermission = ["superadmin", "admin", "mentor"].includes(userRole);
 
   return (
     <main className="bg-white rounded-xl p-6 w-full text-center h-[inherit] max-h-[calc(100vh-114px)] overflow-auto">
@@ -33,10 +62,7 @@ export default function HomePage() {
                 height={64}
                 className="rounded-full border-2 border-white"
               />
-              <small
-                className="font-bold"
-                style={{ textTransform: "uppercase" }}
-              >
+              <small className="font-bold" style={{ textTransform: "uppercase" }}>
                 {user.displayName}
               </small>
               <button
@@ -61,11 +87,15 @@ export default function HomePage() {
                 <label htmlFor="terms">
                   <input name="terms" type="checkbox" /> Acepto términos legales
                 </label>
-                {error && (
-                  <div className="error-message text-red-500 my-4">{error}</div>
-                )}
+                {error && <div className="error-message text-red-500 my-4">{error}</div>}
               </div>
             </div>
+          )}
+
+          {hasPermission && (
+            <ButtonComponent onClick={openModal} className="mt-4">
+              Add users
+            </ButtonComponent>
           )}
         </article>
         <div>
@@ -94,6 +124,7 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+      {isModalOpen && hasPermission && <AddUsersModal onClose={closeModal} userRole={userRole} userID={user.id} />}
     </main>
   );
 }


### PR DESCRIPTION
# Features
- Added `AddUserModal` component to let superadmins, admins and mentors create new users
- Created `userRole` state in the `Homepage` to check the role according to the github_id in the `localStorage` (placeholder, it’s more secure than reading it directly from the `UseContext` that gets it from localStorage but let’s define this better on the weekly as it is out of the scope of the PR). If the `userRole` has the privilege to create other users, it will see the  **Add Users** button in the Homepage.
- Added `endpointRoles` to handle the **GET** and **POST** endpoints for the new roles APIs, (create-role branch in the backend). Updated `config.ts` with the new endpoints
- Added testing to `endPointRoles.test.ts`
# Screenshots
## Add User Button
![image](https://github.com/user-attachments/assets/b5eb2842-1aeb-42ac-9465-50598587c73c)
## Modal
![image (1)](https://github.com/user-attachments/assets/b6b02265-7c38-4d34-80b4-b8b46a07a0e9)
## Database before the push
![image (2)](https://github.com/user-attachments/assets/f94fe468-db5d-4a3c-a82e-27b1ed7718a7)
## After
![image (3)](https://github.com/user-attachments/assets/c3de93e2-553b-4302-b786-f48bf09705ed)
## The **POST** API point used by this PR is in the backend branch `remotes/origin/feature/create-role` which i think it's still not merged to main
# Future changes
1. Update the get endpoint to the `api/login` which is in another branch
2. Design
