### PR TITLE
Fix/create role user

### DIFF
--- a/src/moock/roles.json
+++ b/src/moock/roles.json
@@ -1,7 +1,7 @@
 {
   "message": "Role found.",
   "role": {
-    "github_id": 4,
-    "role": "admin"
+    "github_id": 1,
+    "role": "superadmin"
   }
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,7 +25,6 @@ export default function HomePage() {
     } else {
       setUserRole(null);
     }
-    console.log(user.id);
   }, [user]);
 
   const openModal = () => setIsModalOpen(true);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,7 +5,7 @@ import { useCtxUser } from "../hooks/useCtxUser";
 import { useState, useEffect } from "react";
 import { AddUsersModal } from "../components/resources/AddUserModal";
 import ButtonComponent from "../components/atoms/ButtonComponent";
-import { getRole } from "../api/endPointRoles";
+import { getUserRole } from "../api/userApi";
 
 export default function HomePage() {
   const { signOut, user } = useCtxUser();
@@ -14,9 +14,9 @@ export default function HomePage() {
 
   useEffect(() => {
     if (user && user.id) {
-      getRole(user.id)
+      getUserRole(user.id)
         .then((roleData) => {
-          setUserRole(roleData?.role || null);
+          setUserRole(roleData || null);
         })
         .catch((err) => {
           console.error("Error fetching role:", err);
@@ -25,6 +25,7 @@ export default function HomePage() {
     } else {
       setUserRole(null);
     }
+    console.log(user.id);
   }, [user]);
 
   const openModal = () => setIsModalOpen(true);


### PR DESCRIPTION
- the getRole hook on endPointRoles.ts changed to the getUserRole in userApi.ts as per the backend changes
- Still using state to check the validity of the user role in the local Storage, so that you can't access restricted functionality just by changing your role in it (placeholder, as right now this means doing one extra api call to double check your role, slowing down the page)