### PR TITLE
#135#138 menu de idiomas se cierre eliminar el botton de header

### DIFF
--- a/src/components/Layout/HeaderComponent.tsx
+++ b/src/components/Layout/HeaderComponent.tsx
@@ -28,6 +28,7 @@ const HeaderComponent = () => {
   const [showLangDropdown, setShowLangDropdown] = useState(false);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const langDropdownRef = useRef<HTMLDivElement>(null);
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false);
 
   useEffect(() => {
@@ -45,6 +46,12 @@ const HeaderComponent = () => {
         !dropdownRef.current.contains(event.target as Node)
       ) {
         setShowDropdown(false);
+      }
+      if (
+        langDropdownRef.current &&
+        !langDropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowLangDropdown(false);
       }
     };
 
@@ -115,7 +122,7 @@ const HeaderComponent = () => {
         )}
 
         {/* LANG SELECT DROPDOWN */}
-        <div className="relative">
+        <div className="relative" ref={langDropdownRef}>
           <ButtonComponent
             variant="custom"
             className="inline-flex items-center justify-center h-[41px] px-4 text-[#808080] border-2 rounded-[10px] border-white bg-white hover:bg-[#dcdcdc] hover:border-[#808080] hover:scale-95 transition cursor-pointer"

--- a/src/components/Layout/HeaderComponent.tsx
+++ b/src/components/Layout/HeaderComponent.tsx
@@ -30,10 +30,6 @@ const HeaderComponent = () => {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false);
 
-  const goToResourcesPage = () => {
-    navigate("/resources/add");
-  };
-
   useEffect(() => {
     const resourcePath =
       location.pathname.split("/resources/")[1]?.split("?")[0] || "";
@@ -116,14 +112,6 @@ const HeaderComponent = () => {
             variant="icon"
             text="Añadir Usuario"
           ></ButtonComponent>
-        )}
-
-        {user && (
-          <ButtonComponent
-            icon={addIcon}
-            variant="icon"
-            onClick={goToResourcesPage}
-          />
         )}
 
         {/* LANG SELECT DROPDOWN */}


### PR DESCRIPTION
Se eliminó el botón ‘Añadir Recurso’ del Header, ya que ahora se encuentra en el Aside. 
Además, se agregó una nueva referencia (ref) para cerrar correctamente el menú desplegable de idiomas al hacer clic fuera de él.
