### PR TITLE
Proper validation for Add Resource

### DIFF
--- a/src/pages/CreateResourcePage.tsx
+++ b/src/pages/CreateResourcePage.tsx
@@ -124,7 +124,10 @@ export default function CreateResourcePage() {
               errors={errors.title?.message}
               className="max-w-[482px] max-h-[2.6rem] border-[0.06rem]  border-gray-300 focus:border-2 focus:border-[#B91879] outline-none "
               maxLength={charLimitTitle}
-              onChange={(e) => setCharCount(e.target.value.length)}
+              onChange={(e) => {
+                setCharCount(e.target.value.length);
+                setValue("title", e.target.value);
+              }}
             />
             <div className="w-1/2">
               <p className="text-sm text-slate-600 -mt-5 text-center ml-75">
@@ -139,6 +142,9 @@ export default function CreateResourcePage() {
               register={register}
               errors={errors.url?.message}
               className="max-w-[482px] max-h-[2.6rem] border-[0.06rem] border-gray-300 focus:border-2 focus:border-[#B91879] outline-none "
+              onChange={(e) => {
+                setValue("url", e.target.value);
+              }}
             />
 
             <h2 className="text-sm text-black font-medium mb-2">Lenguaje</h2>
@@ -317,7 +323,10 @@ export default function CreateResourcePage() {
                 errors={errors.description?.message}
                 className="max-w-[482px] max-h-[4.5rem] border-[0.06rem] border-gray-300 focus:border-[#B91879] outline-none"
                 maxLength={charLimitDescription}
-                onChange={(e) => setCharCount(e.target.value.length)}
+                onChange={(e) => {
+                  setCharCount(e.target.value.length); // TODO separar contador
+                  setValue("description", e.target.value);
+                }}
               />
               <div className="w-1/2">
                 <p className="text-sm text-slate-600 -mt-5 text-center ml-75">

--- a/src/validations/resourceSchema.ts
+++ b/src/validations/resourceSchema.ts
@@ -19,6 +19,7 @@ export const resourceSchema: z.ZodType<Partial<IntResource>> = z.object({
     .string()
     .url({ message: "Debe ser una URL válida. Indica el protocolo" })
     .max(300, { message: "La URL debe tener menos de 300 caracteres" }),
+
   category: z.enum(categories, {
     message: "Por favor, selecciona una categoría válida.",
   }),


### PR DESCRIPTION
Al final no era tan complicado. Con esto, todos los campos validan correctamente a nivel local, mostrando los mensajes de error que tocan en cada momento.

Este PR no hace que se pueda crear un recurso, ya que hay error al contactar con el backend, pero eso se resolverá en otro PR.

Otras observaciones, el contador de carácteres está siendo compartido entre el título y la descripción. Habrá que separarlos en el futuro.