### PR TITLE
Feature/183 less restrictive conditions form

### DIFF
--- a/src/validations/resourceSchema.ts
+++ b/src/validations/resourceSchema.ts
@@ -14,7 +14,7 @@ export const resourceSchema: z.ZodType<Partial<IntResource>> = z.object({
   title: z
     .string()
     .min(10, { message: "El título debe tener al menos 10 caracteres" })
-    .max(50, { message: "El título debe tener menos de 50 caracteres" }),
+    .max(65, { message: "El título debe tener menos de 65 caracteres" }),
 
   description: z
     .string()

--- a/src/validations/resourceSchema.ts
+++ b/src/validations/resourceSchema.ts
@@ -18,8 +18,9 @@ export const resourceSchema: z.ZodType<Partial<IntResource>> = z.object({
 
   description: z
     .string()
-    .min(20, { message: "La descripción debe tener al menos 20 caracteres" })
-    .max(150, { message: "La descripción debe tener menos de 150 caracteres" }),
+    .max(120, { message: "La descripción debe tener menos de 120 caracteres" })
+    .optional()
+    .or(z.literal("")),
 
   url: z
     .string()


### PR DESCRIPTION
PR creada para corregir las restricciones en el título y la descripción.

- Se ha arreglado el número mínimo (10) y máximo (65) de caracteres del título.
- La descripción ya no es obligatoria, sino opcional.

Relacionado con la User Stories #183 - "Como alumno, puedo crear un recurso con condiciones diferentes en el formulario, menos restrictivas"