### PR TITLE
Only students are allowed to vote

### DIFF
--- a/src/context/LikeContext.tsx
+++ b/src/context/LikeContext.tsx
@@ -19,15 +19,15 @@ export const LikesProvider = ({ children }: { children: React.ReactNode }) => {
   const { user } = useCtxUser();
 
   const fetchLikes = async () => {
-    if (!user?.github_id) return;
-    const likes = await getLikes(user.github_id);
+    if (!user?.id) return;
+    const likes = await getLikes(user.id);
     const ids = likes.map((like) => like.resource_id);
     setLikedResourceIds(ids);
   };
 
   useEffect(() => {
     fetchLikes();
-  }, [user?.github_id]);
+  }, [user?.id]);
 
   const value = {
     likedResourceIds,

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -12,7 +12,7 @@ export function useLikeResources(resource: IntResource) {
   const { refreshResources } = useResources();
 
   const allowedToVote = user?.role == "student" ? true : false;
-  
+
   const resourceId = Number(resource.id);
 
   const [localLiked, setLocalLiked] = useState<boolean>(

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -11,7 +11,8 @@ export function useLikeResources(resource: IntResource) {
   const { user } = useCtxUser();
   const { refreshResources } = useResources();
 
-  const github_id = user?.github_id;
+  const allowedToVote = user?.role == "student" ? true : false;
+  
   const resourceId = Number(resource.id);
 
   const [localLiked, setLocalLiked] = useState<boolean>(
@@ -37,7 +38,7 @@ export function useLikeResources(resource: IntResource) {
   };
 
   const handleLike = async () => {
-    if (!github_id || syncing) return;
+    if (!allowedToVote || syncing) return;
 
     const wasLiked = localLiked;
     const newCount = localCount + (wasLiked ? -1 : 1);
@@ -70,6 +71,6 @@ export function useLikeResources(resource: IntResource) {
     liked: localLiked,
     voteCount: localCount,
     handleLike,
-    disabled: !github_id,
+    disabled: !allowedToVote,
   };
 }

--- a/src/hooks/useLikeToggle.tsx
+++ b/src/hooks/useLikeToggle.tsx
@@ -10,13 +10,13 @@ export const useLikeToggle = () => {
       if (
         !user ||
         user.role !== "student" ||
-        typeof user.github_id !== "number"
+        typeof user.id !== "number"
       ) {
         console.warn("User not allowed to vote.");
         return { success: false };
       }
 
-      const github_id = user.github_id;
+      const github_id = user.id;
 
       try {
         if (isLiked) {

--- a/src/hooks/useLikeToggle.tsx
+++ b/src/hooks/useLikeToggle.tsx
@@ -7,11 +7,7 @@ export const useLikeToggle = () => {
 
   const toggleLike = useCallback(
     async (resource_id: number, isLiked: boolean) => {
-      if (
-        !user ||
-        user.role !== "student" ||
-        typeof user.id !== "number"
-      ) {
+      if (!user || user.role !== "student" || typeof user.id !== "number") {
         console.warn("User not allowed to vote.");
         return { success: false };
       }


### PR DESCRIPTION
Esto estaba parcialmente implementado antes, pero apuntaba a `github_id` el cual parece que siempre está vacío? Por eso ahora usa `id`.

No hay mucho que enseñar, el botón está desactivado cuando no eres alumno pero si lo eres, puedes votar.
![image](https://github.com/user-attachments/assets/b755c8ba-ae5d-4e13-a96f-e0254caec334)
