### PR TITLE
change dev mode shortcut to Ctrl+Shift+R

### DIFF
--- a/src/components/Layout/HeaderComponent.tsx
+++ b/src/components/Layout/HeaderComponent.tsx
@@ -70,7 +70,11 @@ const HeaderComponent = () => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "r") {
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === "r"
+      ) {
         e.preventDefault();
         setDevMode((prev) => !prev);
       }

--- a/src/components/Layout/HeaderComponent.tsx
+++ b/src/components/Layout/HeaderComponent.tsx
@@ -70,7 +70,7 @@ const HeaderComponent = () => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.altKey && e.key === "R") {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "r") {
         e.preventDefault();
         setDevMode((prev) => !prev);
       }


### PR DESCRIPTION
Now, to open dev mode (feature flag) at our wiki.. you can use Ctrl+Shift+R but still let you use Ctrl+Shift+Alt+R. With that change, Linux users, Mac and Windows shouldn't have problems to open dev tools while in the wiki.