### PR TITLE
Fix: Add fallback role creation when user doesn't exist in database

### DIFF
--- a/src/api/endPointChangeRole.test.tsx
+++ b/src/api/endPointChangeRole.test.tsx
@@ -39,7 +39,7 @@ describe("changeRole", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(mockRoleRequest),
         signal: expect.any(AbortSignal),
-      },
+      }
     );
     expect(result).toEqual(mockRoleResponse);
   });
@@ -61,19 +61,19 @@ describe("changeRole", () => {
     });
 
     await expect(changeRole(mockRoleRequest)).rejects.toThrow(
-      "API Error: Invalid role specified",
+      "API Error: Invalid role specified"
     );
   });
 
   it("should handle AbortError on timeout", async () => {
     const abortError = new DOMException(
       "The operation was aborted",
-      "AbortError",
+      "AbortError"
     );
     global.fetch = vi.fn().mockRejectedValue(abortError);
 
     await expect(changeRole(mockRoleRequest)).rejects.toThrow(
-      "The operation was aborted",
+      "The operation was aborted"
     );
 
     expect(console.warn).toHaveBeenCalledWith("Petition cancelled.");

--- a/src/api/endPointChangeRole.test.tsx
+++ b/src/api/endPointChangeRole.test.tsx
@@ -5,6 +5,8 @@ import {
   RoleChangeResponse,
   changeRole,
 } from "./endPointChangeRole";
+import * as getCurrentUserIdModule from "../utils/getCurrentUserId";
+import * as endPointRolesModule from "./endPointRoles";
 
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -75,5 +77,93 @@ describe("changeRole", () => {
     );
 
     expect(console.warn).toHaveBeenCalledWith("Petition cancelled.");
+  });
+});
+
+// Tests for the 422 error handling
+describe("422 Error Handling", () => {
+  const mockCurrentUserId = 9999;
+
+  beforeEach(() => {
+    vi.spyOn(getCurrentUserIdModule, "getCurrentUserId").mockReturnValue(
+      mockCurrentUserId
+    );
+
+    vi.spyOn(endPointRolesModule, "createRole").mockResolvedValue({
+      message: "Role created successfully",
+      role: { github_id: mockCurrentUserId, role: "student" },
+    });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({ message: "User not found" }),
+    });
+  });
+
+  it("should attempt to create role when status is 422 and role is student", async () => {
+    const studentRoleRequest = { github_id: 12345, role: "student" };
+
+    const result = await changeRole(studentRoleRequest);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_URL}${END_POINTS.devTools.roleChange}`,
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify(studentRoleRequest),
+      })
+    );
+
+    expect(getCurrentUserIdModule.getCurrentUserId).toHaveBeenCalled();
+
+    expect(endPointRolesModule.createRole).toHaveBeenCalledWith({
+      github_id: mockCurrentUserId,
+      role: "student",
+      authorized_github_id: 1,
+    });
+
+    expect(result).toEqual({
+      message: "Role created successfully",
+      role: { github_id: mockCurrentUserId, role: "student" },
+    });
+  });
+
+  it("should attempt to create role when status is 422 and role is mentor", async () => {
+    const mentorRoleRequest = { github_id: 12345, role: "mentor" };
+
+    const result = await changeRole(mentorRoleRequest);
+
+    expect(endPointRolesModule.createRole).toHaveBeenCalledWith({
+      github_id: mockCurrentUserId,
+      role: "mentor",
+      authorized_github_id: 1,
+    });
+
+    expect(result).toEqual({
+      message: "Role created successfully",
+      role: { github_id: mockCurrentUserId, role: "student" },
+    });
+  });
+
+  it("should not attempt to create role when status is 422 but role is admin", async () => {
+    const adminRoleRequest = { github_id: 12345, role: "admin" };
+
+    await expect(changeRole(adminRoleRequest)).rejects.toThrow(
+      "User not found"
+    );
+
+    expect(global.fetch).toHaveBeenCalled();
+
+    expect(endPointRolesModule.createRole).not.toHaveBeenCalled();
+  });
+
+  it("should not attempt to create role when status is 422 but role is superadmin", async () => {
+    const superadminRoleRequest = { github_id: 12345, role: "superadmin" };
+
+    await expect(changeRole(superadminRoleRequest)).rejects.toThrow(
+      "User not found"
+    );
+
+    expect(endPointRolesModule.createRole).not.toHaveBeenCalled();
   });
 });

--- a/src/api/endPointChangeRole.ts
+++ b/src/api/endPointChangeRole.ts
@@ -1,4 +1,6 @@
 import { API_URL, END_POINTS } from "../config";
+import { getCurrentUserId } from "../utils/getCurrentUserId";
+import { createRole } from "./endPointRoles";
 
 interface RoleChangeRequest {
   github_id: number;
@@ -33,6 +35,28 @@ const changeRole = async (
     });
 
     clearTimeout(timeout);
+
+    // Handle 422 error - User id not found in the database
+    if (response.status === 422 && ["student", "mentor"].includes(body.role)) {
+      try {
+        const GithubId = getCurrentUserId();
+        if (!GithubId) {
+          throw new Error("No user ID found on localStorage/context.");
+        }
+
+        const createRoleRequest = {
+          github_id: GithubId,
+          role: body.role,
+          authorized_github_id: 1,
+        };
+        const result = await createRole(createRoleRequest);
+
+        return result;
+      } catch (fallbackError) {
+        console.error("Fallback role creation error:", fallbackError);
+        throw fallbackError;
+      }
+    }
 
     if (!response.ok) {
       const errorData = await response.json();

--- a/src/api/endPointChangeRole.ts
+++ b/src/api/endPointChangeRole.ts
@@ -16,7 +16,7 @@ interface RoleChangeResponse {
 }
 
 const changeRole = async (
-  body: RoleChangeRequest,
+  body: RoleChangeRequest
 ): Promise<RoleChangeResponse> => {
   const controller = new AbortController();
   const signal = controller.signal;
@@ -61,7 +61,7 @@ const changeRole = async (
     if (!response.ok) {
       const errorData = await response.json();
       throw new Error(
-        errorData.message || `Error ${response.status}: ${response.statusText}`,
+        errorData.message || `Error ${response.status}: ${response.statusText}`
       );
     }
 

--- a/src/utils/getCurrentUserId.ts
+++ b/src/utils/getCurrentUserId.ts
@@ -1,0 +1,20 @@
+/*
+ * Wrapper function to get the current user's GitHub ID
+ * allowing us to easily change the source
+ * when we switch from localStorage to context
+ */
+
+//TODO: Refactor this function to use the context instead of localStorage
+
+export const getCurrentUserId = (): number | null => {
+  try {
+    const userDataString = localStorage.getItem("user");
+    if (!userDataString) return null;
+
+    const userData = JSON.parse(userDataString);
+    return userData?.id || null;
+  } catch (error) {
+    console.error("Error getting user ID from localStorage:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Changes
- Added fallback mechanism when role change returns 422 error (user not found in DB)
- For student and mentor roles, attempts to create role using POST /api/roles
- Added tests for the 422 error handling flow
- Created reusable getCurrentUserId utility for future context migration

## Motivation
Previously, if a user without an existing role in the database (e.g., someone who just signed in or after a DB reset) attempted to change their role in dev mode, the system would throw a 422 error (github_id not found in DB). This required manual intervention via Swagger to create the user's role before they could proceed.

With this update, the process is now automatic for the student and mentor roles. If the system encounters a 422 error due to a missing user, it will automatically attempt to create the appropriate role instead of failing.