### PR TITLE
Feature/#243 update vote icon style and color

### DIFF
--- a/src/components/resources/LikeIcon.tsx
+++ b/src/components/resources/LikeIcon.tsx
@@ -10,7 +10,7 @@ const LikeIcon: FC<LikeIconProps> = ({ liked = false }) => {
     <Triangle
       size={16}
       fill={liked ? "rgb(39, 174, 96)" : "none"}
-      color={liked ? "rgb(39, 174, 96)" : "gray"}
+      color={liked ? "rgb(39, 174, 96)" : "black"}
       aria-label={liked ? "Me gusta" : ""}
     />
   );

--- a/src/components/resources/LikeIcon.tsx
+++ b/src/components/resources/LikeIcon.tsx
@@ -9,8 +9,7 @@ const LikeIcon: FC<LikeIconProps> = ({ liked = false }) => {
   return (
     <Triangle
       size={16}
-      fill={liked ? "rgb(39, 174, 96)" : "none"}
-      color={liked ? "rgb(39, 174, 96)" : "black"}
+      className={`${liked ? "text-green-custom fill-green-custom" : "text-black"}`}
       aria-label={liked ? "Me gusta" : ""}
     />
   );

--- a/src/components/resources/LikeIcon.tsx
+++ b/src/components/resources/LikeIcon.tsx
@@ -9,8 +9,8 @@ const LikeIcon: FC<LikeIconProps> = ({ liked = false }) => {
   return (
     <Triangle
       size={16}
-      fill={liked ? "green" : "none"}
-      color={liked ? "green" : "gray"}
+      fill={liked ? "rgb(39, 174, 96)" : "none"}
+      color={liked ? "rgb(39, 174, 96)" : "gray"}
       aria-label={liked ? "Me gusta" : ""}
     />
   );

--- a/src/components/resources/LikeIcon.tsx
+++ b/src/components/resources/LikeIcon.tsx
@@ -2,15 +2,15 @@ import { FC } from "react";
 import { Triangle } from "lucide-react";
 
 interface LikeIconProps {
-  liked?: boolean;
+  active?: boolean;
 }
 
-const LikeIcon: FC<LikeIconProps> = ({ liked = false }) => {
+const LikeIcon: FC<LikeIconProps> = ({ active = false }) => {
   return (
     <Triangle
       size={16}
-      className={`${liked ? "text-green-custom fill-green-custom" : "text-black"}`}
-      aria-label={liked ? "Me gusta" : ""}
+      className={`${active ? "text-green-custom fill-green-custom" : "text-black"}`}
+      aria-label={active ? "Me gusta" : ""}
     />
   );
 };

--- a/src/components/ui/ResourceCard.tsx
+++ b/src/components/ui/ResourceCard.tsx
@@ -106,8 +106,15 @@ const ResourceCard: FC<ResourceCardProps> = ({
             disabled ? "opacity-70 cursor-not-allowed" : "cursor-pointer"
           }`}
         >
-          <LikeIcon liked={liked} />
-          <span className="text-sm font-medium">{voteCount}</span>
+          <LikeIcon liked={voteCount > 0} />
+
+          <span
+            className={`text-sm font-medium ${
+              voteCount > 0 ? "text-green-custom" : "text-black"
+            }`}
+          >
+            {voteCount}
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/ui/ResourceCard.tsx
+++ b/src/components/ui/ResourceCard.tsx
@@ -24,7 +24,7 @@ const ResourceCard: FC<ResourceCardProps> = ({
 
   const { user } = useUserContext();
 
-  const { liked, voteCount, handleLike, disabled } = useLikeResources(resource);
+  const { voteCount, handleLike, disabled } = useLikeResources(resource);
 
   const { getBookmarkCount } = useResources();
 
@@ -106,7 +106,7 @@ const ResourceCard: FC<ResourceCardProps> = ({
             disabled ? "opacity-70 cursor-not-allowed" : "cursor-pointer"
           }`}
         >
-          <LikeIcon liked={voteCount > 0} />
+          <LikeIcon active={voteCount > 0} />
 
           <span
             className={`text-sm font-medium ${

--- a/src/components/ui/ResourceCard.tsx
+++ b/src/components/ui/ResourceCard.tsx
@@ -102,7 +102,7 @@ const ResourceCard: FC<ResourceCardProps> = ({
         </div>
         <div
           onClick={() => !disabled && handleLike()}
-          className={`flex flex-col items-center justify-center border border-gray-200 rounded-lg px-3 py-2 ${
+          className={`flex flex-col items-center justify-center border border-gray-200 rounded-lg px-4 py-2 ${
             disabled ? "opacity-70 cursor-not-allowed" : "cursor-pointer"
           }`}
         >

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -15,24 +15,19 @@ export function useLikeResources(resource: IntResource) {
 
   const resourceId = Number(resource.id);
 
-  const [localLiked, setLocalLiked] = useState<boolean>(
-    likedResourceIds.includes(resourceId),
-  );
   const [localCount, setLocalCount] = useState<number>(
-    resource.like_count ?? 0,
+    resource.like_count ?? 0
   );
 
   const [syncing, setSyncing] = useState(false);
 
   useEffect(() => {
     if (!syncing) {
-      setLocalLiked(likedResourceIds.includes(resourceId));
       setLocalCount(resource.like_count ?? 0);
     }
   }, [likedResourceIds, resourceId, syncing, resource.like_count]);
 
   const rollback = (wasLiked: boolean) => {
-    setLocalLiked(wasLiked);
     setLocalCount((prev) => prev + (wasLiked ? -1 : 1)); // Restablecer el contador optimista
     setLikedResourceIds(likedResourceIds);
   };
@@ -40,10 +35,9 @@ export function useLikeResources(resource: IntResource) {
   const handleLike = async () => {
     if (!allowedToVote || syncing) return;
 
-    const wasLiked = localLiked;
+    const wasLiked = likedResourceIds.includes(resourceId);
     const newCount = localCount + (wasLiked ? -1 : 1);
 
-    setLocalLiked(!wasLiked);
     setLocalCount(newCount);
     setSyncing(true);
 
@@ -68,7 +62,6 @@ export function useLikeResources(resource: IntResource) {
   };
 
   return {
-    liked: localLiked,
     voteCount: localCount,
     handleLike,
     disabled: !allowedToVote,

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -16,7 +16,7 @@ export function useLikeResources(resource: IntResource) {
   const resourceId = Number(resource.id);
 
   const [localCount, setLocalCount] = useState<number>(
-    resource.like_count ?? 0
+    resource.like_count ?? 0,
   );
 
   const [syncing, setSyncing] = useState(false);

--- a/src/index.css
+++ b/src/index.css
@@ -49,7 +49,6 @@ body {
   stroke: rgb(39, 174, 96);
 }
 
-
 /* @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,16 @@ body {
   background-color: #ebebeb;
 }
 
+.text-green-custom {
+  color: rgb(39, 174, 96);
+}
+
+.fill-green-custom {
+  fill: rgb(39, 174, 96);
+  stroke: rgb(39, 174, 96);
+}
+
+
 /* @media (prefers-color-scheme: light) {
   :root {
     color: #213547;


### PR DESCRIPTION
### ✨ Cambios realizados

- Se eliminó el estado `liked` del hook `useLikeResources` para simplificar la lógica.
- Ahora se usa directamente `voteCount > 0` para determinar si el recurso está likeado.
- El componente `LikeIcon` ha sido refactorizado:
  - Se reemplazó la prop `liked` por `active`.
  - Se simplificó el uso de clases de color (`text-green-custom`). (Había utilizado rgb como primera opción en alguno de los commits previos).
- Se ajustaron los estilos del botón de votos:
  - Se ajustó el padding (`px-4 py-2`) para dar aspecto más cuadrado. (El icono actual no es el mismo que en Figma, y es más alto y menos achatado que el del modelo, por lo que no termina de quedar exactamente que en el diseño).
  - El número de votos cambia de color si `voteCount > 0`. Si cambia votecount, ya hace que cambie el color y el icono de triángulo. Si no hay ningún voto, no se activa y se mantienen de color negro ambos.

### 🧪 Cómo testear

1. Iniciar sesión como estudiante.
2. Verificar que el botón de like  se vea más cuadrado.
3. Al dar like:
   - El triángulo debe volverse verde.
   - El número debe volverse verde si es mayor a 0.
4. Al quitar el like:
   - Todo debe volver a color negro.
5. Probar en varios recursos para verificar consistencia.

### 🧹 Otros

- Se eliminaron props y estados no utilizados.
- Código más limpio y predecible al usar solo `voteCount` como fuente de verdad.
