### PR TITLE
Fix: Green vote state only for user's own votes (#260)

### DIFF
--- a/src/components/ui/ResourceCard.tsx
+++ b/src/components/ui/ResourceCard.tsx
@@ -24,7 +24,7 @@ const ResourceCard: FC<ResourceCardProps> = ({
 
   const { user } = useUserContext();
 
-  const { voteCount, handleLike, disabled } = useLikeResources(resource);
+  const { voteCount, handleLike, disabled, isLikedByUser } = useLikeResources(resource);
 
   const { getBookmarkCount } = useResources();
 
@@ -112,11 +112,11 @@ const ResourceCard: FC<ResourceCardProps> = ({
             disabled ? "opacity-70 cursor-not-allowed" : "cursor-pointer"
           }`}
         >
-          <LikeIcon active={voteCount > 0} />
+          <LikeIcon active={isLikedByUser} />
 
           <span
             className={`text-sm font-medium ${
-              voteCount > 0 ? "text-green-custom" : "text-black"
+              isLikedByUser ? "text-green-custom" : "text-black"
             }`}
           >
             {voteCount}

--- a/src/components/ui/ResourceCard.tsx
+++ b/src/components/ui/ResourceCard.tsx
@@ -24,7 +24,8 @@ const ResourceCard: FC<ResourceCardProps> = ({
 
   const { user } = useUserContext();
 
-  const { voteCount, handleLike, disabled, isLikedByUser } = useLikeResources(resource);
+  const { voteCount, handleLike, disabled, isLikedByUser } =
+    useLikeResources(resource);
 
   const { getBookmarkCount } = useResources();
 

--- a/src/context/ResourcesContext.tsx
+++ b/src/context/ResourcesContext.tsx
@@ -16,6 +16,8 @@ interface ResourcesContextType {
   toggleBookmark: (resource: IntResource) => void;
   getBookmarkCount: (resourceId: number | string) => number;
   refreshResources: () => void;
+  updateResourceLikeCount: (resourceId: number, newCount: number) => void;
+
 }
 
 const ResourcesContext = createContext<ResourcesContextType>({
@@ -27,6 +29,7 @@ const ResourcesContext = createContext<ResourcesContextType>({
   toggleBookmark: () => {},
   getBookmarkCount: () => 0,
   refreshResources: () => {},
+  updateResourceLikeCount: () => {},
 });
 
 export const useResources = () => useContext(ResourcesContext);
@@ -46,6 +49,8 @@ export const ResourcesProvider = ({
   const [bookmarkCounts, setBookmarkCounts] = useState<
     Record<string | number, number>
   >({});
+
+  
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -88,6 +93,16 @@ export const ResourcesProvider = ({
       console.error("Error refreshing resources:", err);
     }
   };
+
+  const updateResourceLikeCount = (resourceId: number, newCount: number) => {
+  setResources(prev => 
+    prev.map(resource => 
+      resource.id === resourceId 
+        ? { ...resource, like_count: newCount }
+        : resource
+    )
+  );
+};
 
   useEffect(() => {
     if (!user || resources.length === 0) {
@@ -140,7 +155,7 @@ export const ResourcesProvider = ({
     };
 
     fetchBookmarks();
-  }, [user, resources]);
+  }, [user]);
 
   const { toggleBookmark: toggleBookmarkAction } = useBookmarkToggle();
 
@@ -227,6 +242,7 @@ export const ResourcesProvider = ({
         toggleBookmark,
         getBookmarkCount,
         refreshResources,
+        updateResourceLikeCount,
       }}
     >
       {children}

--- a/src/context/ResourcesContext.tsx
+++ b/src/context/ResourcesContext.tsx
@@ -17,7 +17,6 @@ interface ResourcesContextType {
   getBookmarkCount: (resourceId: number | string) => number;
   refreshResources: () => void;
   updateResourceLikeCount: (resourceId: number, newCount: number) => void;
-
 }
 
 const ResourcesContext = createContext<ResourcesContextType>({
@@ -49,8 +48,6 @@ export const ResourcesProvider = ({
   const [bookmarkCounts, setBookmarkCounts] = useState<
     Record<string | number, number>
   >({});
-
-  
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -95,14 +92,14 @@ export const ResourcesProvider = ({
   };
 
   const updateResourceLikeCount = (resourceId: number, newCount: number) => {
-  setResources(prev => 
-    prev.map(resource => 
-      resource.id === resourceId 
-        ? { ...resource, like_count: newCount }
-        : resource
-    )
-  );
-};
+    setResources((prev) =>
+      prev.map((resource) =>
+        resource.id === resourceId
+          ? { ...resource, like_count: newCount }
+          : resource,
+      ),
+    );
+  };
 
   useEffect(() => {
     if (!user || resources.length === 0) {

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -65,5 +65,6 @@ export function useLikeResources(resource: IntResource) {
     voteCount: localCount,
     handleLike,
     disabled: !allowedToVote,
+    isLikedByUser: likedResourceIds.includes(resourceId),
   };
 }

--- a/src/hooks/useLikeResources.tsx
+++ b/src/hooks/useLikeResources.tsx
@@ -9,7 +9,7 @@ export function useLikeResources(resource: IntResource) {
   const { likedResourceIds, setLikedResourceIds } = useContext(LikeContext);
   const { toggleLike } = useLikeToggle();
   const { user } = useUserContext();
-  const { refreshResources } = useResources();
+  const { updateResourceLikeCount } = useResources();
 
   const allowedToVote = user?.role == "student" ? true : false;
 
@@ -51,7 +51,7 @@ export function useLikeResources(resource: IntResource) {
       if (!result?.success) {
         rollback(wasLiked);
       } else {
-        await refreshResources();
+        await updateResourceLikeCount(resourceId, newCount);
       }
     } catch (err) {
       console.error("Error toggling like:", err);


### PR DESCRIPTION
Motivation
The like button was showing green highlight for any resource with votes > 0, regardless of whether the current user actually voted for it. This created confusion as users couldn't distinguish between resources they personally liked vs. resources liked by others. Additionally, voting was triggering unnecessary resources API calls.

Changes
· Like icon and vote count now turn green only when the current user has voted for the resource
· Added isLikedByUser property that checks if current user's ID is in likedResourceIds array
· ResourceCard now uses isLikedByUser instead of voteCount > 0 for conditional styling
· Removed resources dependency from bookmark useEffect to prevent unnecessary API calls during vote updates
· Eliminated unnecessary refreshResources() calls that were fetching all resources data on every vote