### PR TITLE
Managed to keep logged in when creating a new resource.

### DIFF
--- a/src/pages/CreateResourcePage.tsx
+++ b/src/pages/CreateResourcePage.tsx
@@ -85,7 +85,7 @@ export default function CreateResourcePage() {
       await createResource(resourceWithGithubId);
       toast.success("¡Recurso creado con éxito!");
       setTimeout(() => {
-        navigate(`/resources/${data?.category}`)
+        navigate(`/resources/${data?.category}`);
       }, 1000);
       reset();
     } catch (error) {


### PR DESCRIPTION
Used "navigate" instead of "window.location.href" so that the user will not log out after creating a resource.