### PR TITLE
Hotfix chexboxes default selections removed from TechnicalTestFilter component

### DIFF
--- a/src/components/technical-test/TechnicalTestFilter.tsx
+++ b/src/components/technical-test/TechnicalTestFilter.tsx
@@ -13,17 +13,11 @@ interface TechnicalTestFilterProps {
 export const TechnicalTestFilter: FC<TechnicalTestFilterProps> = ({
   onFiltersChange,
 }) => {
-  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([
-    "JavaScript",
-    "Java",
-  ]);
-  const [selectedYears, setSelectedYears] = useState<string[]>([
-    "2025",
-    "2024",
-  ]);
-  const [selectedDifficulties, setSelectedDifficulties] = useState<string[]>([
-    "Bàsica",
-  ]);
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([]);
+  const [selectedYears, setSelectedYears] = useState<string[]>([]);
+  const [selectedDifficulties, setSelectedDifficulties] = useState<string[]>(
+    [],
+  );
 
   const years = ["2025", "2024", "2023"];
   const difficulties = ["Bàsica", "Intermèdia", "Difícil"];


### PR DESCRIPTION
Removed default selections from TechnicalTestFilter component to show the complete list of card in the TechnicalTestPage.
**Updated:**: TechnicalTestFilter.tsx